### PR TITLE
폴더 수정 오류, FolderList와 MainGrid 동기화

### DIFF
--- a/moamoa/src/App.jsx
+++ b/moamoa/src/App.jsx
@@ -12,6 +12,7 @@ import BrainstormingPage from "./pages/BrainstormingPage.jsx";
 import WordcloudPage from "./pages/WordcloudPage.jsx";
 import NotFoundPage from "./pages/notfoundPage/NotFoundPage.jsx";
 import Layout from "./components/layout/Layout.jsx";
+import ProtectedRoute from "./ProtectedRoute.jsx";
 
 const router = createBrowserRouter([
   { path: "/", element: <Navigate to="/login" replace /> },
@@ -23,16 +24,38 @@ const router = createBrowserRouter([
     path: "/",
     element: <Layout />,
     children: [
-      { path: "main", element: <MainPage /> }, // 메인 페이지
-      { path: "archive/:folderId", element: <ArchivePage /> }, // 아카이브 페이지
+      {
+        path: "main",
+        element: (
+          <ProtectedRoute>
+            <MainPage />
+          </ProtectedRoute>
+        ),
+      },
+      {
+        path: "archive/:folderId",
+        element: (
+          <ProtectedRoute>
+            <ArchivePage />
+          </ProtectedRoute>
+        ),
+      },
       {
         path: "archive/:folderId/brainstorm/:refId",
-        element: <BrainstormingPage />,
-      }, // 브레인스토밍 페이지
+        element: (
+          <ProtectedRoute>
+            <BrainstormingPage />
+          </ProtectedRoute>
+        ),
+      },
       {
         path: "archive/:folderId/wordcloud",
-        element: <WordcloudPage />,
-      }, // 시각화 페이지
+        element: (
+          <ProtectedRoute>
+            <WordcloudPage />
+          </ProtectedRoute>
+        ),
+      },
     ],
   },
 

--- a/moamoa/src/ProtectedRoute.jsx
+++ b/moamoa/src/ProtectedRoute.jsx
@@ -1,0 +1,10 @@
+import { Navigate } from "react-router-dom";
+
+// 로그인 안하면 접근 못하는 경로
+const ProtectedRoute = ({ children }) => {
+  const loginId = localStorage.getItem("loginId");
+
+  return loginId ? children : <Navigate to="/login" replace />;
+};
+
+export default ProtectedRoute;

--- a/moamoa/src/api/folder/setFolderOrderApi.js
+++ b/moamoa/src/api/folder/setFolderOrderApi.js
@@ -1,0 +1,29 @@
+// 폴더 순서 변경 API(PUT)
+import defaultInstance from "../utils/instance";
+
+const setFolderOrderApi = async (folderId, folderOrderAfter) => {
+  const userId = localStorage.getItem("userId");
+  try {
+    const response = await defaultInstance.put(
+      `/user/${userId}/folder/${folderId}/order`,
+      {
+        folderOrderAfter: folderOrderAfter,
+      }
+    );
+
+    const { httpStatus, isSuccess, data, message } = response.data;
+
+    if (httpStatus === 200 && isSuccess) {
+      console.log("폴더 순서 변경 성공:", data);
+      return { success: true, data };
+    } else {
+      console.warn(`폴더 순서 변경 실패:`, message);
+      return { success: false, message };
+    }
+  } catch (error) {
+    console.error("폴더 순서 변경 실패:", error);
+    return { success: false, message: "서버 통신 에러" };
+  }
+};
+
+export default setFolderOrderApi;

--- a/moamoa/src/components/contents/maingrid/MainGrid.jsx
+++ b/moamoa/src/components/contents/maingrid/MainGrid.jsx
@@ -12,7 +12,6 @@ import {
   SortableContext,
   useSortable,
   rectSortingStrategy,
-  arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { restrictToParentElement } from "@dnd-kit/modifiers";
@@ -20,7 +19,7 @@ import "./MainGrid.scss";
 import FolderItem from "./folderitem/FolderItem";
 
 const MainGrid = () => {
-  const { folders, setFolders } = useFolderContext();
+  const { folders, handleReorderFolders } = useFolderContext();
   const navigate = useNavigate();
 
   const sensors = useSensors(
@@ -37,9 +36,7 @@ const MainGrid = () => {
 
   const handleDragEnd = ({ active, over }) => {
     if (active.id !== over?.id) {
-      const oldIndex = folders.findIndex((f) => f.id === active.id);
-      const newIndex = folders.findIndex((f) => f.id === over?.id);
-      setFolders((items) => arrayMove(items, oldIndex, newIndex));
+      handleReorderFolders(active.id, over.id);
     }
   };
 

--- a/moamoa/src/components/contents/maingrid/MainGrid.jsx
+++ b/moamoa/src/components/contents/maingrid/MainGrid.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   DndContext,
   closestCenter,
@@ -20,6 +21,7 @@ import getFolderListApi from "../../../api/folder/getFolderListApi";
 
 const MainGrid = () => {
   const [folders, setFolders] = useState([]);
+  const navigate = useNavigate();
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -28,6 +30,10 @@ const MainGrid = () => {
       },
     })
   );
+
+  const handleFolderClick = (folderId) => {
+    navigate(`/archive/${folderId}`);
+  };
 
   useEffect(() => {
     const fetchFolders = async () => {
@@ -78,6 +84,7 @@ const MainGrid = () => {
                 key={folder.id}
                 id={folder.id}
                 folder={folder}
+                onClick={() => handleFolderClick(folder.id)}
               />
             ))}
           </div>
@@ -87,7 +94,7 @@ const MainGrid = () => {
   );
 };
 
-function SortableFolderItem({ id, folder }) {
+function SortableFolderItem({ id, folder, onClick }) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id });
 
@@ -97,7 +104,13 @@ function SortableFolderItem({ id, folder }) {
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      onClick={onClick}
+    >
       <FolderItem name={folder.name} isEmpty={folder.isEmpty} />
     </div>
   );

--- a/moamoa/src/components/contents/maingrid/MainGrid.jsx
+++ b/moamoa/src/components/contents/maingrid/MainGrid.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
+import { useFolderContext } from "../../../contexts/FolderContext";
 import {
   DndContext,
   closestCenter,
@@ -17,10 +18,9 @@ import { CSS } from "@dnd-kit/utilities";
 import { restrictToParentElement } from "@dnd-kit/modifiers";
 import "./MainGrid.scss";
 import FolderItem from "./folderitem/FolderItem";
-import getFolderListApi from "../../../api/folder/getFolderListApi";
 
 const MainGrid = () => {
-  const [folders, setFolders] = useState([]);
+  const { folders, setFolders } = useFolderContext();
   const navigate = useNavigate();
 
   const sensors = useSensors(
@@ -34,25 +34,6 @@ const MainGrid = () => {
   const handleFolderClick = (folderId) => {
     navigate(`/archive/${folderId}`);
   };
-
-  useEffect(() => {
-    const fetchFolders = async () => {
-      const res = await getFolderListApi();
-      if (res.success) {
-        const formatted = res.data.folderSummeryList.map((folder) => ({
-          id: folder.folderId,
-          name: folder.folderName,
-          isEmpty: folder.isEmpty, // 서버에서 있는지 확인
-          order: folder.folderOrder,
-        }));
-        setFolders(formatted);
-      } else {
-        console.error("폴더 목록 불러오기 실패:", res.message);
-      }
-    };
-
-    fetchFolders();
-  }, []);
 
   const handleDragEnd = ({ active, over }) => {
     if (active.id !== over?.id) {

--- a/moamoa/src/components/layout/Layout.jsx
+++ b/moamoa/src/components/layout/Layout.jsx
@@ -4,20 +4,23 @@ import { Outlet } from "react-router-dom";
 import Header from "./header/Header";
 import FolderList from "./folderlist/FolderList";
 import { DialogProvider } from "../../contexts/DialogContext";
+import { FolderProvider } from "../../contexts/FolderContext";
 
 const Layout = () => {
   return (
     <div className="layout">
       <Header />
       <div className="layout__body">
-        <DialogProvider>
-          <div className="layout__sidebar">
-            <FolderList />
-          </div>
-          <div className="layout__content">
-            <Outlet />
-          </div>
-        </DialogProvider>
+        <FolderProvider>
+          <DialogProvider>
+            <div className="layout__sidebar">
+              <FolderList />
+            </div>
+            <div className="layout__content">
+              <Outlet />
+            </div>
+          </DialogProvider>
+        </FolderProvider>
       </div>
     </div>
   );

--- a/moamoa/src/components/layout/folderlist/FolderList.jsx
+++ b/moamoa/src/components/layout/folderlist/FolderList.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { useFolderContext } from "../../../contexts/FolderContext";
 import {
   DndContext,
   closestCenter,
@@ -9,14 +10,12 @@ import {
 } from "@dnd-kit/core";
 import { restrictToParentElement } from "@dnd-kit/modifiers";
 import {
-  arrayMove,
   SortableContext,
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import "./FolderList.scss";
-import useFolderList from "../../../hooks/useFolderList";
 import { FaPlus } from "react-icons/fa6";
 import FolderListItem from "./FolderListItem";
 import useDialog from "../../../hooks/useDialog";
@@ -29,13 +28,13 @@ const FolderList = () => {
   const MAX_NAME_LENGTH = 5;
   const {
     folders,
-    setFolders,
     editingId,
     setEditingId,
     handleAddFolder,
     handleConfirmDelete,
     handleRenameFolder,
-  } = useFolderList();
+    handleReorderFolders,
+  } = useFolderContext();
 
   // 경로가 archive가 아닐 경우 비활성화
   useEffect(() => {
@@ -80,9 +79,7 @@ const FolderList = () => {
 
   const handleDragEnd = ({ active, over }) => {
     if (active.id !== over?.id) {
-      const oldIndex = folders.findIndex((f) => f.id === active.id);
-      const newIndex = folders.findIndex((f) => f.id === over?.id);
-      setFolders((items) => arrayMove(items, oldIndex, newIndex));
+      handleReorderFolders(active.id, over.id);
     }
   };
 

--- a/moamoa/src/components/layout/folderlist/FolderList.jsx
+++ b/moamoa/src/components/layout/folderlist/FolderList.jsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import {
   DndContext,
   closestCenter,
@@ -18,10 +19,13 @@ import "./FolderList.scss";
 import useFolderList from "../../../hooks/useFolderList";
 import { FaPlus } from "react-icons/fa6";
 import FolderListItem from "./FolderListItem";
-import Dialog from "../../common/dialog/Dialog";
 import useDialog from "../../../hooks/useDialog";
 
 const FolderList = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [activeFolderId, setActiveFolderId] = useState(null); // 더블클릭한 폴더
+
   const MAX_NAME_LENGTH = 5;
   const {
     folders,
@@ -32,6 +36,20 @@ const FolderList = () => {
     handleConfirmDelete,
     handleRenameFolder,
   } = useFolderList();
+
+  // 경로가 archive가 아닐 경우 비활성화
+  useEffect(() => {
+    const isArchiveRoute = /^\/archive(\/|$)/.test(location.pathname);
+    if (!isArchiveRoute) {
+      setActiveFolderId(null);
+    }
+  }, [location.pathname]);
+
+  // 더블클릭 이벤트
+  const handleDoubleClick = (folderId) => {
+    setActiveFolderId(folderId);
+    navigate(`/archive/${folderId}`);
+  };
 
   const formatFolderName = (name) => {
     return name.length > MAX_NAME_LENGTH
@@ -97,6 +115,8 @@ const FolderList = () => {
                 onRequestDelete={() => handleDelete(folder)}
                 onRename={handleRenameFolder}
                 folderNames={folders.map((f) => f.name)}
+                onDoubleClick={handleDoubleClick}
+                isActive={activeFolderId === folder.id}
               />
             ))}
           </div>
@@ -115,6 +135,8 @@ function SortableFolder({
   onRequestDelete,
   onRename,
   folderNames,
+  onDoubleClick,
+  isActive,
 }) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id });
@@ -136,6 +158,8 @@ function SortableFolder({
         onRequestDelete={onRequestDelete}
         onRename={onRename}
         folderNames={folderNames}
+        isActive={isActive}
+        onDoubleClick={onDoubleClick}
       />
     </div>
   );

--- a/moamoa/src/contexts/FolderContext.jsx
+++ b/moamoa/src/contexts/FolderContext.jsx
@@ -1,0 +1,92 @@
+// src/contexts/FolderContext.js
+import React, { createContext, useContext, useEffect, useState } from "react";
+import getFolderListApi from "../api/folder/getFolderListApi";
+import createFolderApi from "../api/folder/createFolderApi";
+import deleteFolderApi from "../api/folder/deleteFolderApi";
+import updateFolderNameApi from "../api/folder/updateFolderNameApi";
+
+const FolderContext = createContext();
+export const useFolderContext = () => useContext(FolderContext);
+
+export const FolderProvider = ({ children }) => {
+  const [folders, setFolders] = useState([]);
+  const [editingId, setEditingId] = useState(null);
+
+  // 1. 폴더 목록 조회
+  const fetchFolders = async () => {
+    const res = await getFolderListApi();
+    if (res.success) {
+      const formatted = res.data.folderSummeryList.map((folder) => ({
+        id: folder.folderId,
+        name: folder.folderName,
+        isEmpty: folder.isEmpty,
+        order: folder.folderOrder,
+      }));
+      setFolders(formatted);
+    } else {
+      console.error("폴더 목록 조회 실패:", res.message);
+    }
+  };
+
+  useEffect(() => {
+    fetchFolders();
+  }, []);
+
+  // 2. 폴더 생성
+  const handleAddFolder = async () => {
+    const res = await createFolderApi("새 폴더");
+    if (res.success) {
+      const newFolder = {
+        id: res.data.id,
+        name: "새 폴더",
+        isEmpty: false,
+        order: folders.length,
+      };
+      setFolders((prev) => [...prev, newFolder]);
+      setEditingId(res.data.id);
+    } else {
+      alert(res.message || "폴더 생성 실패");
+    }
+  };
+
+  // 3. 폴더 삭제
+  const handleConfirmDelete = async (id) => {
+    const res = await deleteFolderApi(id);
+    if (res.success) {
+      setFolders((prev) => prev.filter((f) => f.id !== id));
+    } else {
+      alert(res.message || "폴더 삭제 실패");
+    }
+  };
+
+  // 4. 폴더 이름 수정
+  const handleRenameFolder = async (id, newName) => {
+    const res = await updateFolderNameApi(id, newName);
+    if (res.success) {
+      setFolders((prev) =>
+        prev.map((f) => (f.id === id ? { ...f, name: newName } : f))
+      );
+      return true;
+    } else {
+      alert(res.message || "폴더 이름 수정 실패");
+      return false;
+    }
+  };
+
+  return (
+    <FolderContext.Provider
+      value={{
+        folders,
+        setFolders,
+        editingId,
+        setEditingId,
+        handleAddFolder,
+        handleConfirmDelete,
+        handleRenameFolder,
+        fetchFolders,
+      }}
+    >
+      {children}
+    </FolderContext.Provider>
+  );
+};

--- a/moamoa/src/hooks/useFolderList.js
+++ b/moamoa/src/hooks/useFolderList.js
@@ -1,78 +1,8 @@
-import { useState, useEffect } from "react";
-import getFolderListApi from "../api/folder/getFolderListApi";
-import deleteFolderApi from "../api/folder/deleteFolderApi";
+// useFolderList.js
+import { useFolderContext } from "../contexts/FolderContext";
 
-// 폴더 목록 상태 및 추가, 삭제, 편집
 const useFolderList = () => {
-  const [folders, setFolders] = useState([]);
-  const [editingId, setEditingId] = useState(null); // 편집 여부
-
-  // 폴더 목록 조회
-  useEffect(() => {
-    const fetchFolders = async () => {
-      const res = await getFolderListApi();
-
-      if (res.success) {
-        // folderSummeryList를 변환해서 상태에 저장
-        const formattedFolders = res.data.folderSummeryList.map((folder) => ({
-          id: folder.folderId,
-          name: folder.folderName,
-          order: folder.folderOrder,
-        }));
-        setFolders(formattedFolders);
-      } else {
-        console.error("폴더 목록 로딩 실패:", res.message);
-      }
-    };
-
-    fetchFolders();
-  }, []);
-
-  // 새 폴더 추가
-  const handleAddFolder = () => {
-    const newId =
-      folders.length > 0 ? Math.max(...folders.map((f) => f.id)) + 1 : 1;
-    const newFolder = { id: newId, name: "새 폴더", isNew: true };
-
-    setFolders([...folders, newFolder]);
-    setEditingId(newId);
-  };
-
-  // 폴더 삭제
-  const handleConfirmDelete = async (id) => {
-    const res = await deleteFolderApi(id);
-
-    if (res.success) {
-      setFolders((prev) => prev.filter((f) => f.id !== id));
-    } else {
-      alert(res.message || "폴더 삭제 중 오류가 발생했습니다.");
-    }
-  };
-
-  // 폴더 이름 수정
-  const handleRenameFolder = (tempId, newName, realId = null) => {
-    setFolders((prev) =>
-      prev.map((folder) =>
-        folder.id === tempId
-          ? {
-              ...folder,
-              id: realId ?? tempId,
-              name: newName,
-              isNew: false,
-            }
-          : folder
-      )
-    );
-  };
-  return {
-    folders,
-    setFolders,
-    editingId,
-    setEditingId,
-    handleAddFolder,
-    handleConfirmDelete,
-    handleRenameFolder,
-  };
+  return useFolderContext();
 };
 
 export default useFolderList;


### PR DESCRIPTION
### 변경사항
- 폴더 수정 오류 해결
- FolderList, MainGrid에서 Archive 페이지로 이동
- 폴더 상태 context로 분리 -> FolderList에서 생성/수정/삭제하면 MainGrid에 바로 반영되도록
- 드래그앤드롭으로 순서 변경
- 로그인 안하면 페이지 접근 못하도록

### 관련 이슈
#14 #19 #23 

### 이미지
